### PR TITLE
SCF-10: Rename "Master Calendar" to "Calendar"

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -358,7 +358,7 @@ function Calendar({ student, tagOptions, state}) {
   return (
     <div className="calendar-wrapper">
       <div className="calendar-header">
-        <h2>Master Calendar</h2>
+        <h2>Calendar</h2>
         <span>
           <i>
             *Times are in PT


### PR DESCRIPTION
[SCF-10](https://scfrontend.atlassian.net/browse/SCF-10?atlOrigin=eyJpIjoiYTNiOGEzNzhkNmFmNDVmODkxMTJlODU1NzZjYTEzNWYiLCJwIjoiaiJ9): Rename "Master Calendar" to "Calendar"

To test: verify that on the student dashboard, copy text has changed from "Master Calendar" to "Calendar"

<img width="279" alt="image" src="https://user-images.githubusercontent.com/16441620/137547665-a146ce86-928f-4505-8d5e-1b89d0eae2b6.png">

