### PR TITLE
SCF-8: Remove "Invite-only events are hidden."

### DIFF
--- a/src/pages/student/Dashboard.js
+++ b/src/pages/student/Dashboard.js
@@ -483,7 +483,7 @@ function Dashboard({ student }) {
             </div>
             <span>
               <i>
-                *Only public events displayed. Invite-only events are hidden.
+                *Only public events displayed.
               </i>
             </span>
           </div>

--- a/src/pages/student/studentOnboarding/OnboardingEvents.js
+++ b/src/pages/student/studentOnboarding/OnboardingEvents.js
@@ -40,7 +40,7 @@ const OnboardingEvents = ({ close }) => {
           </p>
           <p className="little-caption">
             <i>
-              Note: Only public events displayed. Invite-only events are hidden.
+              Note: Only public events displayed.
             </i>
           </p>
         </div>


### PR DESCRIPTION
[SCF-8](https://scfrontend.atlassian.net/browse/SCF-8?atlOrigin=eyJpIjoiZGU2MTI3NmIzYzAzNGZkMjk1YzM2YTY4NTExNzc2NjAiLCJwIjoiaiJ9): Remove "Invite-only events are hidden." 

Steps to test:
1. Verify on student dashbord that after "*Only public events displayed." it doesn't say "Invite-only events are hidden."
2. The onboarding modal isn't visible in the develop branch right now, only main, but if it WERE visible, you would verify that after "Note: Only public events displayed." it doesn't say "Invite-only events are hidden."

<img width="536" alt="image" src="https://user-images.githubusercontent.com/16441620/137549524-033e3160-f665-495f-9dd6-a8e23e8f987a.png">


