### PR TITLE
Jenny/scf 11 add whitespace banner

### DIFF
--- a/src/pages/catalog/Catalog.scss
+++ b/src/pages/catalog/Catalog.scss
@@ -16,7 +16,7 @@
   width: 100%;
   height: auto;
   border-radius: 10px;
-  margin-top: 65px;
+  margin-top: 75px;
 }
 .selectedDD {
   border: 1px solid #54a0f1 !important;


### PR DESCRIPTION
[SCF - 11] (sproul.club) add whitespace above banner To Catalog.scssn ".banner img," 
I added margin-top: 65px; to move the entire image down 65 pixels. 

Steps to Test Verify:
1. full banner image is now visible below the navigation bar 

Screenshot:
<img width="1033" alt="Screen Shot 2021-10-19 at 3 31 50 PM" src="https://user-images.githubusercontent.com/21046037/138510439-d7e0a416-ed1b-4ddd-9fe5-9765b30476c9.png">
