### PR TITLE
Jenny/scf 12 calendar days overlayed

### DIFF
--- a/src/components/calendar/Calendar.scss
+++ b/src/components/calendar/Calendar.scss
@@ -24,6 +24,7 @@
 }
 
 .calendar-filters-left {
+    z-index: 900;
     display: flex;
     flex-direction: row;
     align-items: center;


### PR DESCRIPTION
[SCF - 12] (sproul.club) calendar dropdown should overlap the dates 
To Calendar.scss ".calendar-filters-left," I added z-index: 900; to make the calendar filters sit on top of all the other calendar elements 

Steps to Test Verify
1. when the calendar filter dropdown is selected, the dates don't cover the dropdown. 

Screenshots:
<img width="1013" alt="Screen Shot 2021-10-19 at 3 47 32 PM" src="https://user-images.githubusercontent.com/21046037/138510797-a6874cbd-147f-4db1-8fa4-2d235ca6731a.png">
<img width="1006" alt="Screen Shot 2021-10-19 at 3 47 40 PM" src="https://user-images.githubusercontent.com/21046037/138510848-fea52450-65c2-4613-a04f-64b086d7075b.png">
<img width="1003" alt="Screen Shot 2021-10-19 at 3 47 46 PM" src="https://user-images.githubusercontent.com/21046037/138510865-49354168-3c0e-4d54-9c5f-b7bfed2079fd.png">