### PR TITLE
SCF-50: Fix border radius of catalog club card banner images

### DIFF
--- a/src/components/layout/grid/ClubCard.scss
+++ b/src/components/layout/grid/ClubCard.scss
@@ -18,7 +18,7 @@
       width: 100%;
       height: 153px;
       object-fit: cover;
-      border-radius: 10px;
+      border-radius: 9px;
     }
   
     .appreq-tag,


### PR DESCRIPTION
[SCF-50](https://scfrontend.atlassian.net/browse/SCF-50?atlOrigin=eyJpIjoiMGJjNmQxNzdjZDZjNDY4NjgwY2E5YWRhZGZlMjkzMWMiLCJwIjoiaiJ9): Border radius

To test: Open the catalog page and verify that the corners of cards look like this
<img width="447" alt="scrot 5" src="https://user-images.githubusercontent.com/16441620/138515051-4066df2f-a8a6-4f0a-9d8b-b5fc4067a45f.png">
instead of this (how it was before)
<img width="301" alt="scrot 4" src="https://user-images.githubusercontent.com/16441620/138515068-fe1c244c-8f9c-4a5f-ad98-8af48cea6511.png">


